### PR TITLE
fix: add PURE_PYTHON_BUILD to pip install and improve z3_shim imports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,5 +27,8 @@ ivy/js
 **/*.a
 submodules/z3/build
 submodules/picotls/build
+submodules/picotls/CMakeCache.txt
+submodules/picotls/CMakeFiles
+submodules/picotls/Makefile
 submodules/abc/build
 submodules/aiger/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,7 @@ RUN BUILD_MODE=${BUILD_MODE} python3.10 build_submodules.py --skip-z3 && \
             fi; \
         fi ; \
     fi && \
-    sudo python3.10 -m pip install . && \
+    sudo env PURE_PYTHON_BUILD=1 python3.10 -m pip install . && \
     python3.10 -c "import z3; print('Python Z3 version:', z3.get_version_string())" && \
     if [ "$Z3_SOURCE" = "local" ]; then \
         # C++ linking: make libz3.so discoverable by the dynamic linker \

--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -278,7 +278,7 @@ RUN --mount=type=cache,target=/root/.cache/pip-$TARGETPLATFORM,sharing=locked \
             fi; \
         fi ; \
     fi && \
-    sudo python3.10 -m pip install . && \
+    sudo env PURE_PYTHON_BUILD=1 python3.10 -m pip install . && \
     python3.10 -c "import z3; print('Python Z3 version:', z3.get_version_string())" && \
     if [ "$Z3_SOURCE" = "local" ]; then \
         # C++ linking: make libz3.so discoverable by the dynamic linker \

--- a/ivy/z3_shim.py
+++ b/ivy/z3_shim.py
@@ -12,7 +12,11 @@ _local_z3_dir = _os.path.join(_os.path.dirname(_os.path.abspath(__file__)), 'z3'
 _has_local_z3 = _os.path.isfile(_os.path.join(_local_z3_dir, 'z3core.py'))
 
 if _has_local_z3:
-    from .z3 import *
+    # Dynamically emulate 'from .z3 import *' to bypass Griffe/MkDocs static analysis crashes
+    from . import z3 as _local_z3_mod
+    _exports = getattr(_local_z3_mod, '__all__', [k for k in vars(_local_z3_mod) if not k.startswith('_')])
+    globals().update({k: getattr(_local_z3_mod, k) for k in _exports})
+
     # Export underscore-prefixed utilities that wildcard import skips
     try:
         from .z3 import _to_ast_array, _to_expr_ref
@@ -33,12 +37,16 @@ if _has_local_z3:
                 raise Z3Exception(msg)
 else:
     try:
-        from z3 import *
+        # Dynamically emulate 'from z3 import *' to bypass Griffe/MkDocs static analysis crashes
+        import z3 as _system_z3_mod
+        _exports = getattr(_system_z3_mod, '__all__', [k for k in vars(_system_z3_mod) if not k.startswith('_')])
+        globals().update({k: getattr(_system_z3_mod, k) for k in _exports})
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
             "Z3 Python bindings not found. Install via 'pip install z3-solver' "
             "or build from submodule with 'python build_submodules.py'."
         ) from None
+        
     # Export underscore-prefixed utilities that wildcard import skips.
     # Try z3 top-level first, then z3.z3 submodule (where they're defined).
     try:
@@ -56,6 +64,7 @@ else:
     try:
         from z3 import _z3_assert
     except ImportError:
+        from z3 import Z3Exception
         # _z3_assert is defined in z3/z3.py but is underscore-prefixed, so
         # z3/__init__.py's `from .z3 import *` does NOT re-export it (Python
         # convention: wildcard imports skip names starting with '_').
@@ -69,7 +78,7 @@ else:
         #
         # Package __init__.py that causes the import to fail:
         #   https://github.com/Z3Prover/z3/blob/z3-4.13.4/src/api/python/z3/__init__.py
-        from z3 import Z3Exception
         def _z3_assert(cond, msg):
             if not cond:
                 raise Z3Exception(msg)
+            

--- a/ivy_command_mixin.py
+++ b/ivy_command_mixin.py
@@ -461,7 +461,7 @@ class IvyCommandMixin:
         """Build Ivy tool update commands."""
         commands = [
             "echo 'Updating Ivy tool...' >> /app/logs/compile/ivy_setup.log",
-            "cd /opt/panther_ivy && sudo python3.10 -m pip install . >> /app/logs/compile/ivy_setup.log 2>&1",
+            "cd /opt/panther_ivy && sudo env PURE_PYTHON_BUILD=1 python3.10 -m pip install . >> /app/logs/compile/ivy_setup.log 2>&1",
             "cd /opt/panther_ivy && if [ -f lib/libz3.so ]; then cp lib/libz3.so /opt/panther_ivy/ivy/z3/ && echo 'Copied libz3.so to ivy/z3/'; else echo 'No local libz3.so (z3_source=pip), skipping copy'; fi >> /app/logs/compile/ivy_setup.log 2>&1",
             # Ensure target directories exist in the site-packages install
             "mkdir -p \"$PYTHON_IVY_DIR/ivy/include/1.7\" \"$PYTHON_IVY_DIR/ivy/lib\" >> /app/logs/compile/ivy_setup.log 2>&1",


### PR DESCRIPTION
## Summary
- Dockerfiles: use `PURE_PYTHON_BUILD=1` to skip picotls rebuild during pip install (already built by `build_submodules.py`)
- `ivy_command_mixin.py`: same `PURE_PYTHON_BUILD=1` for runtime reinstall
- `z3_shim.py`: dynamic imports to bypass Griffe/MkDocs static analysis crashes
- `.dockerignore`: exclude picotls cmake build artifacts

## Test plan
- [x] Verified Docker build succeeds with these changes
- [x] Verified Ivy test compilation passes

## Summary by Sourcery

Use a pure-Python pip install path for Ivy in Docker and runtime flows and make z3 shim imports compatible with static analysis tools.

Bug Fixes:
- Avoid Griffe/MkDocs crashes by switching z3_shim to dynamic imports that emulate wildcard imports while bypassing static analysis issues.

Enhancements:
- Set PURE_PYTHON_BUILD=1 for pip installs in Docker and runtime update commands to skip unnecessary native picotls rebuilds.
- Exclude picotls CMake build artifacts from Docker build context via .dockerignore updates.

Tests:
- Manually verified Docker image builds successfully and Ivy test compilation passes with the new installation and z3 shim behavior.