### PR TITLE
fix: config schema, Docker cleanup, and build artifact gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,13 @@ __pycache__/
 .pre-commit-cache/
 
 
+# Generated Ivy doc files (mkdocs output)
+ivy/include/1.7/*.md
+
+# Build artifacts (picotls headers and compiled libs)
+ivy/include/picotls/
+ivy/lib/
+
 #Ignore vscode AI rules
 .github/instructions/codacy.instructions.md
 # VSCode extension build artifacts (managed by vscode-ivy submodule's own .gitignore)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ ENV VERSION=${VERSION}
 RUN printf "Building Panther-Ivy version: %s - Dependencies: %s\n" "${VERSION}" "${DEPENDENCIES}"
 
 RUN apt update && \
-    add-apt-repository --yes ppa:deadsnakes/ppa && \
-    apt update && \
     apt --fix-missing -y install \
     build-essential \
     python3-ply \

--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -56,7 +56,6 @@ RUN --mount=type=cache,target=/var/cache/apt-${TARGETPLATFORM},sharing=locked \
     --mount=type=cache,target=/var/lib/apt-${TARGETPLATFORM},sharing=locked \
     apt update && \
     apt install -y software-properties-common && \
-    add-apt-repository --yes ppa:deadsnakes/ppa && \
     apt update && \
     apt --fix-missing -y install \
     build-essential python3-ply alien iptables iproute2 iputils-ping \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Panther Ivy Tester
 
-!!! info "Plugin Information"
-    **Plugin Type**: Service (Tester)
-    **Source Location**: `plugins/services/testers/panther_ivy/`
+> [!NOTE]
+> "Plugin Information"
+> **Plugin Type**: Service (Tester)
+> **Source Location**: `plugins/services/testers/panther_ivy/`
 
-!!! warning "Advanced Testing Tool"
-    Ivy integration requires formal protocol specifications and is intended for advanced users familiar with formal verification methods. For basic protocol testing, consider using standard IUT plugins first.
+> [!WARNING]
+> "Advanced Testing Tool"
+> Ivy integration requires formal protocol specifications and is intended for advanced users familiar with formal verification methods. For basic protocol testing, consider using standard IUT plugins first.
 
 IVy is a research tool intended to allow interactive development of
 protocols and their proofs of correctness and to provide a platform

--- a/config_schema.py
+++ b/config_schema.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from omegaconf import OmegaConf
 from panther.config.core.models.plugin import ServicePluginConfig
 from panther.config.core.models.service import ImplementationType, VersionBase
 from pydantic import BaseModel, Field
@@ -119,7 +118,47 @@ class PantherIvyVersion(VersionBase):
 
 
 class PantherIvyConfig(ServicePluginConfig):
-    """Configuration for Panther Ivy tester service."""
+    """Panther-Ivy formal verification tester configuration.
+
+    Integration with Microsoft's Ivy formal verification tool for
+    specification-based protocol testing. Ivy generates test traffic from
+    formal protocol models and verifies implementation compliance.
+
+    Warning:
+        Ivy integration requires formal protocol specifications and is
+        intended for advanced users familiar with formal verification.
+        First build takes ~30 minutes due to Z3 compilation.
+
+    Z3 Build Modes (``z3_source``):
+        - **local** -- builds Z3 from submodule (~30 min), full compatibility
+        - **pip** -- uses ``pip install z3-solver`` (faster, limited features)
+
+    Compilation Modes (``build_mode``):
+        - **(empty)** -- original method, Shadow NS compatible
+        - **debug-asan** -- AddressSanitizer (``-O1 -g -fsanitize=address``)
+        - **rel-lto** -- Link Time Optimization (``-O3 -flto``)
+        - **release-static-pgo** -- PGO + static linking (``-fprofile-use``)
+
+    Language: C/C++ + Python | Source: panther_ivy submodule
+    Build time: ~30 min (first build) | Docker image: ~1GB
+
+    Inherited from ServicePluginConfig / BasePluginConfig:
+        enabled (bool): Whether the plugin is enabled. Default: True.
+
+    Example YAML::
+
+        services:
+          tester:
+            implementation:
+              name: panther_ivy
+              type: testers
+            protocol:
+              name: quic
+              version: rfc9000
+              role: server
+    """
+
+    VERSION_CLASS = PantherIvyVersion
 
     name: str = Field(default="panther_ivy", description="Implementation name")
     type: ImplementationType = Field(
@@ -196,136 +235,16 @@ class PantherIvyConfig(ServicePluginConfig):
         description="Optimization level for the Ivy binary (O0, O1, O2, O3) - O0 recommended for debugging",
     )
 
-    @staticmethod
-    def load_versions_from_files(
-        version_configs_dir: str = f"{Path(os.path.dirname(__file__))}/version_configs/",
-        protocol: str = "quic",
-        version: Optional[str] = None,
-        protocol_version_override: str = None,
-    ) -> PantherIvyVersion:
-        """Load version configurations dynamically from YAML files.
-
-        Args:
-            version_configs_dir: Directory containing version configs (auto-detected if None)
-            protocol: Protocol name for version directory (default: quic)
-            version: Specific version to load (loads first found if None)
-
-        Returns:
-            PantherIvyVersion configuration
-        """
-        import logging
-
-        logging.debug(
-            "Loading PantherIvy versions with protocol: %s, version: %s",
-            protocol,
-            version,
-        )
-        version = (
-            version if not protocol_version_override else protocol_version_override
-        )
-        if version_configs_dir is None:
-            # Auto-detect based on protocol
-            base_dir = Path(os.path.dirname(__file__)) / "version_configs"
-            version_configs_dir = str(base_dir / protocol)
-            logging.debug("Using version configs directory: %s", version_configs_dir)
-        # Fallback to base directory if protocol-specific directory doesn't exist
-        if not os.path.exists(version_configs_dir):
-            logging.warning(
-                f"Protocol-specific directory {version_configs_dir} not found, trying base directory"
-            )
-            version_configs_dir = str(
-                Path(os.path.dirname(__file__)) / "version_configs"
-            )
-
-        if not os.path.exists(version_configs_dir):
-            logging.warning(
-                f"Version configs directory {version_configs_dir} not found, using defaults"
-            )
-            return PantherIvyVersion()
-
-        logging.debug("Loading PantherIvy versions from %s", version_configs_dir)
-
-        # Find version files
-        version_files = [
-            f for f in os.listdir(version_configs_dir) if f.endswith(".yaml")
-        ]
-        if not version_files:
-            logging.warning(
-                f"No version files found in {version_configs_dir}, using defaults"
-            )
-            return PantherIvyVersion()
-
-        # Select specific version or first available
-        target_file = None
-        if version:
-            target_file = f"{version}.yaml"
-            if target_file not in version_files:
-                logging.warning(
-                    f"Requested version {version} not found, using first available"
-                )
-                target_file = None
-
-        if target_file is None:
-            target_file = sorted(version_files)[
-                0
-            ]  # Use first available, sorted for determinism
-
-        version_path = os.path.join(version_configs_dir, target_file)
-        raw_version_config = OmegaConf.load(version_path)
-        logging.debug("Loaded raw PantherIvy version config: %s", raw_version_config)
-
-        # Create default instance and convert to dict for merging
-        default_version = PantherIvyVersion()
-        try:
-            # Try Pydantic v2 method first
-            default_dict = default_version.model_dump()
-        except AttributeError:
-            # Fall back to Pydantic v1 method
-            default_dict = default_version.dict()
-
-        merged_config = OmegaConf.merge(default_dict, raw_version_config)
-
-        # Ensure client and server are in the config before conversion
-        if "client" not in merged_config or merged_config.client is None:
-            merged_config.client = {}
-        if "server" not in merged_config or merged_config.server is None:
-            merged_config.server = {}
-
-        # Convert OmegaConf to dict and create proper Pydantic model
-        version_dict = OmegaConf.to_container(merged_config, resolve=True)
-        version_config = PantherIvyVersion(**version_dict)
-
-        logging.debug(
-            "Loaded PantherIvy version %s from %s",
-            version_config.version if hasattr(version_config, "version") else "unknown",
-            target_file,
-        )
-        return version_config
-
     @classmethod
-    def create_with_protocol_context(cls, protocol=None):
-        """Create PantherIvyConfig instance with optional protocol context.
-
-        # TODO refactor duplicated code
-
-        If protocol version is provided, loads version-specific configuration.
-        Otherwise creates standard instance.
-
-        Args:
-            protocol: Optional protocol configuration containing version info
-
-        Returns:
-            PantherIvyConfig instance with appropriate version configuration
-        """
-        logging.debug("Creating PantherIvyConfig with protocol context")
-        if protocol and hasattr(protocol, "version") and protocol.version:
-            try:
-                version_config = cls.load_versions_from_files(
-                    protocol_version_override=protocol.version
-                )
-                return cls(version=version_config)
-            except (FileNotFoundError, ValueError) as e:
-                raise ValueError(
-                    f"Could not load protocol version {protocol.version}: {e}"
-                ) from e
-        return cls()
+    def load_version(
+        cls,
+        version_configs_dir: Optional[str] = None,
+        version: Optional[str] = None,
+        protocol_version_override: Optional[str] = None,
+    ):
+        """Override to look in ``version_configs/quic/`` subdirectory."""
+        if version_configs_dir is None:
+            quic_dir = Path(os.path.dirname(__file__)) / "version_configs" / "quic"
+            if quic_dir.exists():
+                version_configs_dir = str(quic_dir)
+        return super().load_version(version_configs_dir, version, protocol_version_override)

--- a/config_schema.py
+++ b/config_schema.py
@@ -175,6 +175,12 @@ class PantherIvyConfig(ServiceConfig):
         description="Protocol configuration",
     )
 
+    # Typed version (loaded from version_configs/)
+    version: PantherIvyVersion = Field(
+        default_factory=lambda: PantherIvyConfig.load_version(),
+        description="Version configuration",
+    )
+
     test: str = Field(default="", description="Test name for testers")
     use_system_models: bool = Field(
         default=False, description="Use system models for the test"

--- a/config_schema.py
+++ b/config_schema.py
@@ -1,11 +1,17 @@
 import logging
 import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 
-from panther.config.core.models.plugin import ServicePluginConfig
-from panther.config.core.models.service import ImplementationType, VersionBase
 from pydantic import BaseModel, Field
+
+from panther.config.core.models.service import (
+    ImplementationConfig,
+    ImplementationType,
+    ProtocolConfig,
+    ServiceConfig,
+    VersionBase,
+)
 
 
 class AvailableTests(BaseModel):
@@ -117,7 +123,7 @@ class PantherIvyVersion(VersionBase):
     )
 
 
-class PantherIvyConfig(ServicePluginConfig):
+class PantherIvyConfig(ServiceConfig):
     """Panther-Ivy formal verification tester configuration.
 
     Integration with Microsoft's Ivy formal verification tool for
@@ -142,9 +148,6 @@ class PantherIvyConfig(ServicePluginConfig):
     Language: C/C++ + Python | Source: panther_ivy submodule
     Build time: ~30 min (first build) | Docker image: ~1GB
 
-    Inherited from ServicePluginConfig / BasePluginConfig:
-        enabled (bool): Whether the plugin is enabled. Default: True.
-
     Example YAML::
 
         services:
@@ -158,31 +161,24 @@ class PantherIvyConfig(ServicePluginConfig):
               role: server
     """
 
-    VERSION_CLASS = PantherIvyVersion
+    VERSION_CLASS: ClassVar[Optional[type]] = PantherIvyVersion
 
-    name: str = Field(default="panther_ivy", description="Implementation name")
-    type: ImplementationType = Field(
-        default=ImplementationType.TESTERS, description="Implementation type"
+    # Override required fields with plugin-specific defaults
+    implementation: ImplementationConfig = Field(
+        default_factory=lambda: ImplementationConfig(
+            name="panther_ivy", type="testers"
+        ),
+        description="Implementation configuration",
     )
+    protocol: ProtocolConfig = Field(
+        default_factory=lambda: ProtocolConfig(name="quic", role="server"),
+        description="Protocol configuration",
+    )
+
     test: str = Field(default="", description="Test name for testers")
     use_system_models: bool = Field(
         default=False, description="Use system models for the test"
     )
-    shadow_compatible: bool = Field(
-        default=True, description="Whether compatible with Shadow network simulator"
-    )
-    gperf_compatible: bool = Field(
-        default=True, description="Whether compatible with gperf profiling"
-    )
-
-    # protocol: str = Field(
-    #     default="quic",
-    #     description="Protocol tested by the implementation"
-    # )
-    # version: PantherIvyVersion = Field(
-    #     default_factory=lambda: PantherIvyConfig.load_versions_from_files(),
-    #     description="Version configuration"
-    # )
 
     environment: Dict[str, str] = Field(
         default_factory=lambda: DEFAULT_ENVIRONMENT_VARIABLES.copy(),

--- a/panther_ivy.py
+++ b/panther_ivy.py
@@ -143,8 +143,7 @@ class PantherIvyServiceManager(
 
         self.outputs = {}
 
-        # Cache plugin config for easy access
-        self._plugin_config = None
+        # Plugin config cache removed — fields now live on service_config_to_test directly
 
     def get_build_mode(self) -> str:
         """
@@ -157,24 +156,8 @@ class PantherIvyServiceManager(
         Returns:
             Build mode string: '', 'debug-asan', 'rel-lto', or 'release-static-pgo'
         """
-        # Check plugin_config first (only if key actually exists)
-        if (
-            hasattr(self, "service_config_to_test")
-            and hasattr(self.service_config_to_test, "plugin_config")
-            and isinstance(self.service_config_to_test.plugin_config, dict)
-            and "build_mode" in self.service_config_to_test.plugin_config
-        ):
-            build_mode = self.service_config_to_test.plugin_config["build_mode"]
-            if build_mode:
-                return build_mode
-
-        # Fallback to implementation config (where YAML extras go via setattr)
-        if hasattr(self, "service_config_to_test") and hasattr(
-            self.service_config_to_test, "implementation"
-        ):
-            build_mode = getattr(
-                self.service_config_to_test.implementation, "build_mode", None
-            )
+        if hasattr(self, "service_config_to_test"):
+            build_mode = getattr(self.service_config_to_test, "build_mode", None)
             if build_mode:
                 return build_mode
 
@@ -186,24 +169,8 @@ class PantherIvyServiceManager(
         Controls whether Z3 is built from the local submodule ('local')
         or installed only via pip z3-solver ('pip').
         """
-        # Check plugin_config first (only if key actually exists)
-        if (
-            hasattr(self, "service_config_to_test")
-            and hasattr(self.service_config_to_test, "plugin_config")
-            and isinstance(self.service_config_to_test.plugin_config, dict)
-            and "z3_source" in self.service_config_to_test.plugin_config
-        ):
-            z3_source = self.service_config_to_test.plugin_config["z3_source"]
-            if z3_source:
-                return z3_source
-
-        # Fallback to implementation config (where YAML extras go via setattr)
-        if hasattr(self, "service_config_to_test") and hasattr(
-            self.service_config_to_test, "implementation"
-        ):
-            z3_source = getattr(
-                self.service_config_to_test.implementation, "z3_source", None
-            )
+        if hasattr(self, "service_config_to_test"):
+            z3_source = getattr(self.service_config_to_test, "z3_source", None)
             if z3_source:
                 return z3_source
 
@@ -225,18 +192,14 @@ class PantherIvyServiceManager(
         # Set test configuration -> use comprehensive multi-level checking
         test_name = ""
 
-        # Priority order: test_parameters  plugin_config  implementation  direct attribute
+        # Priority order: test_parameters -> direct attribute -> implementation fallback
         if (
             hasattr(service_config_to_test, "test_parameters")
             and service_config_to_test.test_parameters
         ):
             test_name = service_config_to_test.test_parameters.get("test", "")
-        elif (
-            hasattr(service_config_to_test, "plugin_config")
-            and service_config_to_test.plugin_config
-        ):
-            # Check plugin_config dict for test -> this is where it actually is!
-            test_name = service_config_to_test.plugin_config.get("test", "")
+        elif hasattr(service_config_to_test, "test") and service_config_to_test.test:
+            test_name = service_config_to_test.test
         elif hasattr(service_config_to_test, "implementation"):
             # Check if the implementation is a dict with 'test' key
             if (
@@ -247,12 +210,6 @@ class PantherIvyServiceManager(
             # Check if implementation has test attribute
             elif hasattr(service_config_to_test.implementation, "test"):
                 test_name = service_config_to_test.implementation.test
-        elif hasattr(service_config_to_test, "test"):
-            # Check if service_config has test attribute directly
-            test_name = service_config_to_test.test
-        else:
-            # Final fallback to direct attribute access
-            test_name = getattr(service_config_to_test, "test", "")
 
         # Validate test_to_compile to prevent shell injection via config
         _SAFE_TEST_NAME = re.compile(r"^[a-zA-Z0-9_\-]*$")
@@ -770,42 +727,6 @@ class PantherIvyServiceManager(
             self.logger.debug(
                 "Docker attributes already initialized, skipping duplicate setup"
             )
-
-    # def _get_plugin_config(self) -> Optional[PantherIvyConfig]:
-    #     """
-    #     Get plugin config for ServiceManagerDockerMixin integration.
-
-    #     This method provides the plugin configuration needed by the Docker mixin
-    #     for container setup and volume mapping.
-
-    #     Returns:
-    #         PantherIvyConfig: The service configuration object
-    #     """
-    #     # Cache the plugin config to avoid repeated access
-    #     if self._plugin_config is None:
-    #         try:
-    #             self._plugin_config = self.service_config_to_test.get_plugin_config(PantherIvyConfig)
-    #         except Exception as e:
-    #             self.logger.debug(f"Could not get plugin config, using defaults: {e}")
-    #             # Create default config
-    #             self._plugin_config = PantherIvyConfig()
-
-    #     self.logger.debug(f"Loaded plugin config: {self._plugin_config}")
-
-    #     # Get protocol version for version-specific configuration loading
-    #     protocol_version = getattr(self.service_config_to_test.protocol, 'version', None)
-    #     protocol_name = self._get_protocol_name()
-
-    #     self.logger.info(
-    #         f"Loading version config for {self.implementation_name}: "
-    #         f"protocol={protocol_name}, version={protocol_version}"
-    #     )
-
-    #     self._plugin_config.load_versions_from_files(
-    #         protocol=protocol_name,
-    #         version=protocol_version,
-    #     )
-    #     return self._plugin_config
 
     def _do_prepare(self, plugin_manager: Optional["PluginManager"] = None):
         """Implementation of abstract _do_prepare method from IServiceManager."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,10 @@ Homepage = "https://github.com/ElNiak/Panther-IVy"
 Repository = "https://github.com/ElNiak/Panther-IVy"
 Issues = "https://github.com/ElNiak/Panther-IVy/issues"
 
+
 [tool.setuptools.packages.find]
 include = ["ivy", "ivy.*", "api", "api.*"]
+exclude = ["docs*", "tests*", "scripts*", "outputs*","__pycache__*","site*", "*.egg-info", "*.dist-info", "build*", "dist*",".venv*", "venv*"]
 
 [tool.setuptools.package-data]
 ivy = [


### PR DESCRIPTION
## Summary
- Refactored `PantherIvyConfig` to inherit from `ServiceConfig` and use the `VERSION_CLASS` pattern from base
- Removed direct `plugin_config` dict access in favor of typed config attributes
- Added `version` field to `PantherIvyConfig` to fix unknown field warnings
- Removed dead `ppa:deadsnakes/ppa` from both Dockerfiles
- Converted MkDocs admonitions to GitHub-compatible blockquotes in README
- Added `exclude` rule to setuptools packages in `pyproject.toml`
- Updated `.gitignore` to ignore generated `.md` docs and build artifacts (`ivy/include/picotls/`, `ivy/lib/`)
- Updated `ivy-lsp` submodule pointer (import path fix for standalone usage)

## Test plan
- [ ] Verify Docker build still works with updated Dockerfiles
- [ ] Confirm `PantherIvyConfig` loads without unknown field warnings
- [ ] Check that `ivy-lsp` MCP server works standalone (outside panther package)

## Summary by Sourcery

Align Panther Ivy tester configuration with core service config models and clean up project packaging and build artifacts.

Bug Fixes:
- Ensure PantherIvyConfig defines a typed version field to avoid unknown field warnings when loading configs.
- Update ivy-lsp submodule reference to fix standalone MCP server import paths.

Enhancements:
- Refactor PantherIvyConfig to inherit from ServiceConfig and use core Implementation/Protocol config objects instead of plugin_config dict access.
- Simplify Panther Ivy runtime configuration access by reading build and test parameters directly from the service config instance.
- Convert README admonitions to GitHub-compatible blockquote syntax for better rendering on GitHub.

Build:
- Remove deprecated deadsnakes PPA usage from Dockerfiles.
- Tighten setuptools package discovery with explicit exclude patterns for docs, tests, scripts, and build output directories.
- Extend .gitignore to ignore generated markdown docs and native build artifacts under ivy/include and ivy/lib.