### PR TITLE
chore: add package exclusions for htmlcov, .claude, pytest-of-*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ Issues = "https://github.com/ElNiak/Panther-IVy/issues"
 
 [tool.setuptools.packages.find]
 include = ["ivy", "ivy.*", "api", "api.*"]
-exclude = ["docs*", "tests*", "scripts*", "outputs*","__pycache__*","site*", "*.egg-info", "*.dist-info", "build*", "dist*",".venv*", "venv*"]
+exclude = ["docs*", "tests*", "scripts*", "outputs*", "__pycache__*", "site*", "*.egg-info", "*.dist-info", "build*", "dist*", ".venv*", "venv*", "htmlcov*", ".claude*", "pytest-of-*"]
 
 [tool.setuptools.package-data]
 ivy = [


### PR DESCRIPTION
## Summary
- Add htmlcov, .claude, and pytest-of-* to package exclusions in pyproject.toml
- Fixes submodule pointer alignment: this commit was on the feature branch but missed PR #14

## Context
Cherry-picked from `fix/config-and-docker-cleanup` — the one commit that wasn't included in PR #14.
PANTHER production currently points to this commit, so it needs to be on panther_ivy production.